### PR TITLE
Remove UnPack

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,6 @@ version = "0.1.0"
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
-UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [weakdeps]
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
@@ -18,5 +17,4 @@ BipartiteGraphsSparseArraysExt = "SparseArrays"
 DocStringExtensions = "0.7, 0.8, 0.9"
 Graphs = "1.5.2"
 SparseArrays = "1"
-UnPack = "1"
 julia = "1.10"

--- a/src/BipartiteGraphs.jl
+++ b/src/BipartiteGraphs.jl
@@ -1,7 +1,6 @@
 module BipartiteGraphs
 
 using DocStringExtensions
-using UnPack
 using Graphs
 
 export Matching, Unassigned, unassigned

--- a/src/bipartite_graph.jl
+++ b/src/bipartite_graph.jl
@@ -38,7 +38,7 @@ Obtain the destination vertex of a [`BipartiteEdge`](@ref).
 Graphs.dst(edge::BipartiteEdge) = edge.dst
 
 function Base.show(io::IO, edge::BipartiteEdge)
-    @unpack src, dst = edge
+    (; src, dst) = edge
     print(io, "[src: ", src, "] => [dst: ", dst, "]")
 end
 
@@ -244,7 +244,7 @@ nsrcs(g::BipartiteGraph) = length(𝑠vertices(g))
 ndsts(g::BipartiteGraph) = length(𝑑vertices(g))
 
 function Graphs.has_edge(g::BipartiteGraph, edge::BipartiteEdge)
-    @unpack src, dst = edge
+    (; src, dst) = edge
     (src in 𝑠vertices(g) && dst in 𝑑vertices(g)) || return false  # edge out of bounds
     insorted(dst, 𝑠neighbors(g, src))
 end
@@ -267,7 +267,7 @@ end
 Add `edge` to graph `g`.
 """
 function Graphs.add_edge!(g::BipartiteGraph, edge::BipartiteEdge, md = NO_METADATA)
-    @unpack fadjlist, badjlist = g
+    (; fadjlist, badjlist) = g
     s, d = src(edge), dst(edge)
     (has_𝑠vertex(g, s) && has_𝑑vertex(g, d)) || error("edge ($edge) out of range.")
     @inbounds list = fadjlist[s]
@@ -301,7 +301,7 @@ end
 Femove `edge` from graph `g`.
 """
 function Graphs.rem_edge!(g::BipartiteGraph, edge::BipartiteEdge)
-    @unpack fadjlist, badjlist = g
+    (; fadjlist, badjlist) = g
     s, d = src(edge), dst(edge)
     (has_𝑠vertex(g, s) && has_𝑑vertex(g, d)) || error("edge ($edge) out of range.")
     @inbounds list = fadjlist[s]
@@ -440,7 +440,7 @@ Base.eltype(it::BipartiteEdgeIter) = edgetype(it.g)
 
 function Base.iterate(it::BipartiteEdgeIter{SRC, <:BipartiteGraph{T}},
         state = (1, 1, SRC)) where {T}
-    @unpack g = it
+    (; g) = it
     neqs = nsrcs(g)
     neqs == 0 && return nothing
     eq, jvar = state
@@ -462,7 +462,7 @@ end
 
 function Base.iterate(it::BipartiteEdgeIter{DST, <:BipartiteGraph{T}},
         state = (1, 1, DST)) where {T}
-    @unpack g = it
+    (; g) = it
     nvars = ndsts(g)
     nvars == 0 && return nothing
     ieq, jvar = state


### PR DESCRIPTION
There should be no need for UnPack on Julia >= 1.10. In fact, `UnPack.@unpack` is pretty bad as it creates `Val` dispatches; this caused major compilation time problems in OrdinaryDiffEq a few years ago and hence it was replaced with https://github.com/devmotion/SimpleUnPack.jl (see https://github.com/devmotion/SimpleUnPack.jl#comparison-with-unpackjl). But on Julia >= 1.7 that package just uses the native `(; ...) = ...` syntax, so there's no need for it here either.