### PR TITLE
Fix minimum version bounds for DocStringExtensions and Graphs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,8 +17,8 @@ BipartiteGraphsSparseArraysExt = "SparseArrays"
 
 [compat]
 DataStructures = "0.18, 0.19"
-DocStringExtensions = "0.7, 0.8, 0.9"
-Graphs = "1.5.2"
+DocStringExtensions = "0.8, 0.9"
+Graphs = "1.9"
 PrecompileTools = "1"
 SparseArrays = "1"
 julia = "1.10"


### PR DESCRIPTION
## Summary

This PR fixes incorrect minimum version bounds for two dependencies that were discovered through minimum version testing:

- **DocStringExtensions**: `0.7` → `0.8`
- **Graphs**: `1.5.2` → `1.9`

## Issues Found

### 1. DocStringExtensions minimum version too low

**Problem**: The codebase uses the `TYPEDFIELDS` macro in `src/hypergraph.jl:31`, but this macro was not available in v0.7.

**Evidence**: When testing with DocStringExtensions v0.7.0:
```
ERROR: UndefVarError: `TYPEDFIELDS` not defined in `BipartiteGraphs`
```

**Research**: `TYPEDFIELDS` was added in [DocStringExtensions v0.8.0](https://github.com/JuliaDocs/DocStringExtensions.jl).

**Fix**: Updated minimum version from `0.7` to `0.8`.

### 2. Graphs minimum version too low

**Problem**: The test suite calls `eltype(g)` on `BipartiteGraph` instances, but Graphs v1.5.2 doesn't provide the instance method delegation.

**Evidence**: When testing with Graphs v1.5.2:
```
ERROR: method eltype not implemented.
```

**Research**: The delegation `eltype(g::AbstractGraph) = eltype(typeof(g))` was added in [Graphs v1.9.0](https://github.com/JuliaGraphs/Graphs.jl) (PR #144 by @lmondada).

**Fix**: Updated minimum version from `1.5.2` to `1.9`.

## Testing

All changes were validated by:
1. Installing the minimum versions of each dependency
2. Running the full test suite with those versions
3. Verifying all 536 tests pass

## Test Evidence

With the corrected bounds, all tests pass:
```
Test Summary:      | Pass  Total   Time
BipartiteGraphs.jl |  536    536  15.4s
     Testing BipartiteGraphs tests passed
```

cc: @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)