### PR TITLE
Switch from JuliaFormatter to Runic.jl for code formatting

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,2 +1,0 @@
-style = "sciml"
-format_markdown = true

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,14 +1,19 @@
-name: "Format Check"
+name: format-check
 
 on:
   push:
     branches:
       - 'master'
-      - v10
+      - 'main'
+      - 'release-'
     tags: '*'
   pull_request:
 
 jobs:
-  format-check:
-    name: "Format Check"
-    uses: "SciML/.github/.github/workflows/format-suggestions-on-pr.yml@v1"
+  runic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: fredrikekre/runic-action@v1
+        with:
+          version: '1'

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,7 +7,8 @@ const ExtMod = Base.get_extension(BipartiteGraphs, :BipartiteGraphsSparseArraysE
 cp("./docs/Manifest.toml", "./docs/src/assets/Manifest.toml", force = true)
 cp("./docs/Project.toml", "./docs/src/assets/Project.toml", force = true)
 
-makedocs(sitename = "BipartiteGraphs.jl",
+makedocs(
+    sitename = "BipartiteGraphs.jl",
     authors = "Chris Rackauckas",
     modules = [BipartiteGraphs, ExtMod],
     clean = true, doctest = false, linkcheck = true,
@@ -15,11 +16,15 @@ makedocs(sitename = "BipartiteGraphs.jl",
     format = Documenter.HTML(;
         assets = ["assets/favicon.ico"],
         canonical = "https://docs.sciml.ai/BipartiteGraphs/stable/",
-        prettyurls = (get(ENV, "CI", nothing) == "true")),
+        prettyurls = (get(ENV, "CI", nothing) == "true")
+    ),
     pages = [
         "Home" => "index.md",
-        "api.md"
-    ])
+        "api.md",
+    ]
+)
 
-deploydocs(repo = "github.com/SciML/BipartiteGraphs.jl.git";
-    push_preview = true)
+deploydocs(
+    repo = "github.com/SciML/BipartiteGraphs.jl.git";
+    push_preview = true
+)

--- a/ext/BipartiteGraphsSparseArraysExt.jl
+++ b/ext/BipartiteGraphsSparseArraysExt.jl
@@ -19,7 +19,7 @@ function Graphs.incidence_matrix(g::BipartiteGraph, val = true)
         push!(I, i)
         push!(J, n)
     end
-    S = sparse(I, J, val, nsrcs(g), ndsts(g))
+    return S = sparse(I, J, val, nsrcs(g), ndsts(g))
 end
 
 end

--- a/src/BipartiteGraphs.jl
+++ b/src/BipartiteGraphs.jl
@@ -15,8 +15,8 @@ include("matching.jl")
 
 export BipartiteEdge, BipartiteGraph
 export 𝑠vertices, 𝑑vertices, has_𝑠vertex, has_𝑑vertex, 𝑠neighbors, 𝑑neighbors,
-       𝑠edges, 𝑑edges, nsrcs, ndsts, SRC, DST, set_neighbors!, invview,
-       delete_srcs!, delete_dsts!, complete, require_complete
+    𝑠edges, 𝑑edges, nsrcs, ndsts, SRC, DST, set_neighbors!, invview,
+    delete_srcs!, delete_dsts!, complete, require_complete
 include("bipartite_graph.jl")
 
 export maximal_matching, construct_augmenting_path!

--- a/src/bipartite_graph.jl
+++ b/src/bipartite_graph.jl
@@ -19,7 +19,7 @@ struct BipartiteEdge{I <: Integer} <: Graphs.AbstractEdge{I}
     dst::I
     function BipartiteEdge(src::I, dst::V) where {I, V}
         T = promote_type(I, V)
-        new{T}(T(src), T(dst))
+        return new{T}(T(src), T(dst))
     end
 end
 
@@ -39,7 +39,7 @@ Graphs.dst(edge::BipartiteEdge) = edge.dst
 
 function Base.show(io::IO, edge::BipartiteEdge)
     (; src, dst) = edge
-    print(io, "[src: ", src, "] => [dst: ", dst, "]")
+    return print(io, "[src: ", src, "] => [dst: ", dst, "]")
 end
 
 Base.:(==)(a::BipartiteEdge, b::BipartiteEdge) = src(a) == src(b) && dst(a) == dst(b)
@@ -88,16 +88,20 @@ lookup at the cost of slower edge insertion.
 
 `ne` may be omitted, in which case it is inferred from the forward adjacency list.
 """
-function BipartiteGraph(ne::Integer, fadj::AbstractVector,
+function BipartiteGraph(
+        ne::Integer, fadj::AbstractVector,
         badj::Union{AbstractVector, Integer} = maximum(maximum, fadj);
-        metadata = nothing)
-    BipartiteGraph(ne, fadj, badj, metadata)
+        metadata = nothing
+    )
+    return BipartiteGraph(ne, fadj, badj, metadata)
 end
 
-function BipartiteGraph(fadj::AbstractVector,
+function BipartiteGraph(
+        fadj::AbstractVector,
         badj::Union{AbstractVector, Integer} = maximum(maximum, fadj);
-        metadata = nothing)
-    BipartiteGraph(mapreduce(length, +, fadj; init = 0), fadj, badj, metadata)
+        metadata = nothing
+    )
+    return BipartiteGraph(mapreduce(length, +, fadj; init = 0), fadj, badj, metadata)
 end
 
 """
@@ -106,7 +110,7 @@ end
 Utility function to throw an error if the graph `g` is not [`complete`](@ref).
 """
 @noinline function require_complete(g::BipartiteGraph)
-    g.badjlist isa AbstractVector ||
+    return g.badjlist isa AbstractVector ||
         throw(ArgumentError("The graph has no back edges. Use `complete`."))
 end
 
@@ -118,7 +122,7 @@ returned graph aliases `g`. Requires that `g` is [`complete`](@ref).
 """
 function invview(g::BipartiteGraph)
     require_complete(g)
-    BipartiteGraph(g.ne, g.badjlist, g.fadjlist)
+    return BipartiteGraph(g.ne, g.badjlist, g.fadjlist)
 end
 
 """
@@ -134,7 +138,7 @@ function complete(g::BipartiteGraph{I}) where {I}
             push!(badjlist[d], s)
         end
     end
-    BipartiteGraph(g.ne, g.fadjlist, badjlist)
+    return BipartiteGraph(g.ne, g.fadjlist, badjlist)
 end
 
 """
@@ -146,7 +150,7 @@ function Base.isequal(bg1::BipartiteGraph{T}, bg2::BipartiteGraph{T}) where {T <
     iseq = (bg1.ne == bg2.ne)
     iseq &= (bg1.fadjlist == bg2.fadjlist)
     iseq &= (bg1.badjlist == bg2.badjlist)
-    iseq
+    return iseq
 end
 
 """
@@ -156,16 +160,20 @@ Build an empty [`BipartiteGraph`](@ref) with `nsrcs` sources and `ndsts` destina
 By default, the constructed graph is [`complete`](@ref)d. To avoid this
 and lazily compute backward adjacency, pass `Val(false)` as the third argument.
 """
-function BipartiteGraph(nsrcs::T, ndsts::T, backedge::Val{B} = Val(true);
-        metadata = nothing) where {T, B}
+function BipartiteGraph(
+        nsrcs::T, ndsts::T, backedge::Val{B} = Val(true);
+        metadata = nothing
+    ) where {T, B}
     fadjlist = map(_ -> T[], 1:nsrcs)
     badjlist = B ? map(_ -> T[], 1:ndsts) : ndsts
-    BipartiteGraph(0, fadjlist, badjlist, metadata)
+    return BipartiteGraph(0, fadjlist, badjlist, metadata)
 end
 
 function Base.copy(bg::BipartiteGraph)
-    BipartiteGraph(bg.ne, map(copy, bg.fadjlist), map(copy, bg.badjlist),
-        deepcopy(bg.metadata))
+    return BipartiteGraph(
+        bg.ne, map(copy, bg.fadjlist), map(copy, bg.badjlist),
+        deepcopy(bg.metadata)
+    )
 end
 Base.eltype(::Type{<:BipartiteGraph{I}}) where {I} = I
 
@@ -181,7 +189,7 @@ function Base.empty!(g::BipartiteGraph)
     if g.metadata !== nothing
         foreach(empty!, g.metadata)
     end
-    g
+    return g
 end
 Base.length(::BipartiteGraph) = error("length is not well defined! Use `ne` or `nv`.")
 
@@ -208,7 +216,7 @@ Obtain the number of source vertices in the graph.
 Obtain the number of destination vertices in the graph.
 """
 function 𝑑vertices(g::BipartiteGraph)
-    g.badjlist isa AbstractVector ? axes(g.badjlist, 1) : Base.OneTo(g.badjlist)
+    return g.badjlist isa AbstractVector ? axes(g.badjlist, 1) : Base.OneTo(g.badjlist)
 end
 """
     $TYPEDSIGNATURES
@@ -227,20 +235,24 @@ has_𝑑vertex(g::BipartiteGraph, v::Integer) = v in 𝑑vertices(g)
 
 Obtain the neighbors of source vertex `i` in graph `g`.
 """
-function 𝑠neighbors(g::BipartiteGraph, i::Integer,
-        with_metadata::Val{M} = Val(false)) where {M}
-    M ? zip(g.fadjlist[i], g.metadata[i]) : g.fadjlist[i]
+function 𝑠neighbors(
+        g::BipartiteGraph, i::Integer,
+        with_metadata::Val{M} = Val(false)
+    ) where {M}
+    return M ? zip(g.fadjlist[i], g.metadata[i]) : g.fadjlist[i]
 end
 """
     $TYPEDSIGNATURES
 
 Obtain the neighbors of destination vertex `i` in graph `g`.
 """
-function 𝑑neighbors(g::BipartiteGraph, j::Integer,
-        with_metadata::Val{M} = Val(false)) where {M}
+function 𝑑neighbors(
+        g::BipartiteGraph, j::Integer,
+        with_metadata::Val{M} = Val(false)
+    ) where {M}
     require_complete(g)
     backj = g.badjlist[j]::Vector{Int}
-    M ? zip(backj, (g.metadata[i][j] for i in backj)) : backj
+    return M ? zip(backj, (g.metadata[i][j] for i in backj)) : backj
 end
 Graphs.ne(g::BipartiteGraph) = g.ne
 
@@ -269,7 +281,7 @@ ndsts(g::BipartiteGraph) = length(𝑑vertices(g))
 function Graphs.has_edge(g::BipartiteGraph, edge::BipartiteEdge)
     (; src, dst) = edge
     (src in 𝑠vertices(g) && dst in 𝑑vertices(g)) || return false  # edge out of bounds
-    insorted(dst, 𝑠neighbors(g, src))
+    return insorted(dst, 𝑠neighbors(g, src))
 end
 Base.in(edge::BipartiteEdge, g::BipartiteGraph) = Graphs.has_edge(g, edge)
 
@@ -282,7 +294,7 @@ const NO_METADATA = NoMetadata()
 Add an edge from source `i` to destination `j` in graph `g`.
 """
 function Graphs.add_edge!(g::BipartiteGraph, i::Integer, j::Integer, md = NO_METADATA)
-    add_edge!(g, BipartiteEdge(i, j), md)
+    return add_edge!(g, BipartiteEdge(i, j), md)
 end
 """
     $TYPEDSIGNATURES
@@ -316,7 +328,7 @@ end
 Remove the edge from source `i` to destination `j` in graph `g`.
 """
 function Graphs.rem_edge!(g::BipartiteGraph, i::Integer, j::Integer)
-    Graphs.rem_edge!(g, BipartiteEdge(i, j))
+    return Graphs.rem_edge!(g, BipartiteEdge(i, j))
 end
 """
     $TYPEDSIGNATURES
@@ -330,7 +342,7 @@ function Graphs.rem_edge!(g::BipartiteGraph, edge::BipartiteEdge)
     @inbounds list = fadjlist[s]
     index = searchsortedfirst(list, d)
     @inbounds (index <= length(list) && list[index] == d) ||
-              error("graph does not have edge $edge")
+        error("graph does not have edge $edge")
     deleteat!(list, index)
     g.ne -= 1
     if badjlist isa AbstractVector
@@ -389,7 +401,7 @@ function set_neighbors!(g::BipartiteGraph, i::Integer, new_neighbors)
             end
         end
     end
-    if iszero(new_nneighbors) # this handles Tuple as well
+    return if iszero(new_nneighbors) # this handles Tuple as well
         # Warning: Aliases old_neighbors
         empty!(g.fadjlist[i])
     else
@@ -432,7 +444,7 @@ function delete_srcs!(g::BipartiteGraph{I}, srcs; rm_verts = false) where {I}
         end
         deleteat!(g.fadjlist, srcs)
     end
-    g
+    return g
 end
 
 """
@@ -443,7 +455,7 @@ In graph `g`, remove all edges incident on destination vertices in `srcs`. If `r
 renumbering of destination vertices.
 """
 function delete_dsts!(g::BipartiteGraph, srcs; rm_verts = false)
-    delete_srcs!(invview(g), srcs; rm_verts)
+    return delete_srcs!(invview(g), srcs; rm_verts)
 end
 
 ###
@@ -483,8 +495,10 @@ end
 Base.length(it::BipartiteEdgeIter) = ne(it.g)
 Base.eltype(it::BipartiteEdgeIter) = edgetype(it.g)
 
-function Base.iterate(it::BipartiteEdgeIter{SRC, <:BipartiteGraph{T}},
-        state = (1, 1, SRC)) where {T}
+function Base.iterate(
+        it::BipartiteEdgeIter{SRC, <:BipartiteGraph{T}},
+        state = (1, 1, SRC)
+    ) where {T}
     (; g) = it
     neqs = nsrcs(g)
     neqs == 0 && return nothing
@@ -505,8 +519,10 @@ function Base.iterate(it::BipartiteEdgeIter{SRC, <:BipartiteGraph{T}},
     return nothing
 end
 
-function Base.iterate(it::BipartiteEdgeIter{DST, <:BipartiteGraph{T}},
-        state = (1, 1, DST)) where {T}
+function Base.iterate(
+        it::BipartiteEdgeIter{DST, <:BipartiteGraph{T}},
+        state = (1, 1, DST)
+    ) where {T}
     (; g) = it
     nvars = ndsts(g)
     nvars == 0 && return nothing

--- a/src/condensation_graphs.jl
+++ b/src/condensation_graphs.jl
@@ -15,10 +15,10 @@ function (T::Type{<:AbstractCondensationGraph})(g, sccs::Vector{Union{Int, Vecto
             scc_assignment[v] = i
         end
     end
-    T(g, sccs, scc_assignment)
+    return T(g, sccs, scc_assignment)
 end
 function (T::Type{<:AbstractCondensationGraph})(g, sccs::Vector{Vector{Int}})
-    T(g, Vector{Union{Int, Vector{Int}}}(sccs))
+    return T(g, Vector{Union{Int, Vector{Int}}}(sccs))
 end
 
 Graphs.is_directed(::Type{<:AbstractCondensationGraph}) = true
@@ -53,15 +53,23 @@ struct MatchedCondensationGraph{G <: DiCMOBiGraph} <: AbstractCondensationGraph
 end
 
 function Graphs.outneighbors(mcg::MatchedCondensationGraph, cc::Integer)
-    Iterators.flatten((mcg.scc_assignment[v′]
-                      for v′ in outneighbors(mcg.graph, v) if mcg.scc_assignment[v′] != cc)
-    for v in mcg.sccs[cc])
+    return Iterators.flatten(
+        (
+                mcg.scc_assignment[v′]
+                for v′ in outneighbors(mcg.graph, v) if mcg.scc_assignment[v′] != cc
+            )
+            for v in mcg.sccs[cc]
+    )
 end
 
 function Graphs.inneighbors(mcg::MatchedCondensationGraph, cc::Integer)
-    Iterators.flatten((mcg.scc_assignment[v′]
-                      for v′ in inneighbors(mcg.graph, v) if mcg.scc_assignment[v′] != cc)
-    for v in mcg.sccs[cc])
+    return Iterators.flatten(
+        (
+                mcg.scc_assignment[v′]
+                for v′ in inneighbors(mcg.graph, v) if mcg.scc_assignment[v′] != cc
+            )
+            for v in mcg.sccs[cc]
+    )
 end
 
 """
@@ -86,15 +94,19 @@ struct InducedCondensationGraph{G <: BipartiteGraph} <: AbstractCondensationGrap
 end
 
 function _neighbors(icg::InducedCondensationGraph, cc::Integer)
-    Iterators.flatten(Iterators.flatten(icg.graph.fadjlist[vsrc]
-                      for vsrc in icg.graph.badjlist[v])
-    for v in icg.sccs[cc])
+    return Iterators.flatten(
+        Iterators.flatten(
+                icg.graph.fadjlist[vsrc]
+                for vsrc in icg.graph.badjlist[v]
+            )
+            for v in icg.sccs[cc]
+    )
 end
 
 function Graphs.outneighbors(icg::InducedCondensationGraph, v::Integer)
-    (icg.scc_assignment[n] for n in _neighbors(icg, v) if icg.scc_assignment[n] > v)
+    return (icg.scc_assignment[n] for n in _neighbors(icg, v) if icg.scc_assignment[n] > v)
 end
 
 function Graphs.inneighbors(icg::InducedCondensationGraph, v::Integer)
-    (icg.scc_assignment[n] for n in _neighbors(icg, v) if icg.scc_assignment[n] < v)
+    return (icg.scc_assignment[n] for n in _neighbors(icg, v) if icg.scc_assignment[n] < v)
 end

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,4 +1,5 @@
 @deprecate maximal_matching(g::BipartiteGraph, srcfilter) maximal_matching(g; srcfilter)
 @deprecate maximal_matching(g::BipartiteGraph, srcfilter, dstfilter) maximal_matching(g; srcfilter, dstfilter)
 @deprecate maximal_matching(g::BipartiteGraph, srcfilter, dstfilter, T) maximal_matching(
-    g, T; srcfilter, dstfilter)
+    g, T; srcfilter, dstfilter
+)

--- a/src/dicmobigraph.jl
+++ b/src/dicmobigraph.jl
@@ -32,13 +32,15 @@ the graph formed by expanding each directed hyperedge into `n` ordinary edges
 between the same vertices.
 """
 mutable struct DiCMOBiGraph{Transposed, I, G <: BipartiteGraph{I}, M <: Matching} <:
-               Graphs.AbstractGraph{I}
+    Graphs.AbstractGraph{I}
     graph::G
     ne::Union{Missing, Int}
     matching::M
-    function DiCMOBiGraph{Transposed}(g::G, ne::Union{Missing, Int},
-            m::M) where {Transposed, I, G <: BipartiteGraph{I}, M}
-        new{Transposed, I, G, M}(g, ne, m)
+    function DiCMOBiGraph{Transposed}(
+            g::G, ne::Union{Missing, Int},
+            m::M
+        ) where {Transposed, I, G <: BipartiteGraph{I}, M}
+        return new{Transposed, I, G, M}(g, ne, m)
     end
 end
 
@@ -48,7 +50,7 @@ end
 Construct a [`DiCMOBiGraph`](@ref) from a bipartite graph with an empty matching.
 """
 function DiCMOBiGraph{Transposed}(g::BipartiteGraph) where {Transposed}
-    DiCMOBiGraph{Transposed}(g, 0, Matching(ndsts(g)))
+    return DiCMOBiGraph{Transposed}(g, 0, Matching(ndsts(g)))
 end
 
 """
@@ -57,7 +59,7 @@ end
 Construct a [`DiCMOBiGraph`](@ref) from a bipartite graph and a matching.
 """
 function DiCMOBiGraph{Transposed}(g::BipartiteGraph, m::M) where {Transposed, M}
-    DiCMOBiGraph{Transposed}(g, missing, m)
+    return DiCMOBiGraph{Transposed}(g, missing, m)
 end
 
 """
@@ -67,15 +69,15 @@ Return a [`DiCMOBiGraph`](@ref) with the source and destination vertices swapped
 returned graph aliases `g`.
 """
 function invview(g::DiCMOBiGraph{Transposed}) where {Transposed}
-    DiCMOBiGraph{!Transposed}(invview(g.graph), g.ne, invview(g.matching))
+    return DiCMOBiGraph{!Transposed}(invview(g.graph), g.ne, invview(g.matching))
 end
 
 Graphs.is_directed(::Type{<:DiCMOBiGraph}) = true
 function Graphs.nv(g::DiCMOBiGraph{Transposed}) where {Transposed}
-    Transposed ? ndsts(g.graph) : nsrcs(g.graph)
+    return Transposed ? ndsts(g.graph) : nsrcs(g.graph)
 end
 function Graphs.vertices(g::DiCMOBiGraph{Transposed}) where {Transposed}
-    Transposed ? 𝑑vertices(g.graph) : 𝑠vertices(g.graph)
+    return Transposed ? 𝑑vertices(g.graph) : 𝑠vertices(g.graph)
 end
 
 """
@@ -89,9 +91,11 @@ struct CMONeighbors{Transposed, V}
     The vertex whose neighbors are being iterated over.
     """
     v::V
-    function CMONeighbors{Transposed}(g::DiCMOBiGraph{Transposed},
-            v::V) where {Transposed, V}
-        new{Transposed, V}(g, v)
+    function CMONeighbors{Transposed}(
+            g::DiCMOBiGraph{Transposed},
+            v::V
+        ) where {Transposed, V}
+        return new{Transposed, V}(g, v)
     end
 end
 
@@ -112,6 +116,7 @@ function Base.iterate(c::CMONeighbors{false}, (l, state...))
         end
         return vsrc, (l, r[2])
     end
+    return
 end
 Base.length(c::CMONeighbors{false}) = count(_ -> true, c)
 
@@ -126,7 +131,7 @@ function _neighbors(c::CMONeighbors{true})
 end
 function Base.length(c::CMONeighbors{true})
     nbors = _neighbors(c)
-    length(@something(nbors, 1)) - 1
+    return length(@something(nbors, 1)) - 1
 end
 
 Graphs.inneighbors(g::DiCMOBiGraph{true}, v) = CMONeighbors{true}(g, v)
@@ -134,7 +139,7 @@ Graphs.outneighbors(g::DiCMOBiGraph{true}, v) = outneighbors(invview(g), v)
 function Base.iterate(c::CMONeighbors{true})
     nbors = _neighbors(c)
     nbors === nothing && return nothing
-    iterate(c, (nbors,))
+    return iterate(c, (nbors,))
 end
 function Base.iterate(c::CMONeighbors{true}, (l, state...))
     while true
@@ -146,12 +151,13 @@ function Base.iterate(c::CMONeighbors{true}, (l, state...))
         end
         return r[1], (l, r[2])
     end
+    return
 end
 
 function _edges(g::DiCMOBiGraph{Transposed}) where {Transposed}
-    Transposed ?
-    ((w => v for w in inneighbors(g, v)) for v in vertices(g)) :
-    ((v => w for w in outneighbors(g, v)) for v in vertices(g))
+    return Transposed ?
+        ((w => v for w in inneighbors(g, v)) for v in vertices(g)) :
+        ((v => w for w in outneighbors(g, v)) for v in vertices(g))
 end
 
 Graphs.edges(g::DiCMOBiGraph) = (Graphs.SimpleEdge(p) for p in Iterators.flatten(_edges(g)))

--- a/src/hypergraph.jl
+++ b/src/hypergraph.jl
@@ -17,7 +17,7 @@ end
 Base.:(==)(a::HyperEdge, b::HyperEdge) = a.id == b.id && a.vertices == b.vertices
 
 function Base.show(io::IO, edge::HyperEdge)
-    print(io, "HyperEdge(", edge.id, ", ", edge.vertices, ")")
+    return print(io, "HyperEdge(", edge.id, ", ", edge.vertices, ")")
 end
 
 """
@@ -134,7 +134,7 @@ Graphs.has_vertex(g::HyperGraph{V}, v::V) where {V} = haskey(g.labels, v)
 Get the number of hyperedges in the hypergraph. Only counts non-empty hyperedges.
 """
 function Graphs.ne(g::HyperGraph)
-    count(!isempty ∘ Base.Fix1(𝑠neighbors, g.graph), 𝑠vertices(g.graph))
+    return count(!isempty ∘ Base.Fix1(𝑠neighbors, g.graph), 𝑠vertices(g.graph))
 end
 
 Graphs.edgetype(::HyperGraph{V}) where {V} = HyperEdge{V}
@@ -147,11 +147,11 @@ or as a collection of vertices.
 """
 function Graphs.has_edge(g::HyperGraph{V}, edge::HyperEdge{V}) where {V}
     edge.id in 𝑠vertices(g.graph) || return false
-    Graphs.has_edge(g, edge.vertices)
+    return Graphs.has_edge(g, edge.vertices)
 end
 
 function Graphs.has_edge(g::HyperGraph{V}, vertices::HyperGraphEdge{V}) where {V}
-    _edge_idx(g, vertices) !== nothing
+    return _edge_idx(g, vertices) !== nothing
 end
 
 function _edge_idx(g::HyperGraph{V}, vertices::HyperGraphEdge{V}) where {V}
@@ -256,7 +256,7 @@ Get the vertices in a hyperedge (specified by its integer ID).
 function neighbors(g::HyperGraph, edge_id::Int)
     edge_id in 𝑠vertices(g.graph) || throw(BoundsError(g, edge_id))
     neighbor_ids = 𝑠neighbors(g.graph, edge_id)
-    [g.invmap[j] for j in neighbor_ids]
+    return [g.invmap[j] for j in neighbor_ids]
 end
 
 """
@@ -275,7 +275,7 @@ function incident_edges(g::HyperGraph{V}, v::V) where {V}
     haskey(g.labels, v) || throw(ArgumentError("Vertex $v not in graph"))
     v_id = g.labels[v]
     edge_ids = 𝑑neighbors(g.graph, v_id)
-    [HyperEdge(i, neighbors(g, i)) for i in edge_ids]
+    return [HyperEdge(i, neighbors(g, i)) for i in edge_ids]
 end
 
 Base.length(::HyperGraph) = error("length is not well defined! Use `ne` or `nv`.")

--- a/src/matching.jl
+++ b/src/matching.jl
@@ -37,17 +37,22 @@ Convert a matching to have element type `Union{V, Int}`.
 Matching{V}(m::Matching) where {V} = convert(Matching{V}, m)
 
 function Base.convert(::Type{Matching{V, A}}, m::Matching) where {
-        V, A <: AbstractVector{Union{V, Int}}}
+        V, A <: AbstractVector{Union{V, Int}},
+    }
     typeof(m) == Matching{V, A} && return m
-    Matching{V}(convert(A, m.match),
-        m.inv_match === nothing ? nothing : convert(A, m.inv_match))
+    return Matching{V}(
+        convert(A, m.match),
+        m.inv_match === nothing ? nothing : convert(A, m.inv_match)
+    )
 end
 
 function Base.convert(::Type{Matching{V}}, m::Matching) where {V}
     eltype(m) === Union{V, Int} && return m
     VUT = typeof(similar(m.match, Union{V, Int}, 0))
-    Matching{V}(convert(VUT, m.match),
-        m.inv_match === nothing ? nothing : convert(VUT, m.inv_match))
+    return Matching{V}(
+        convert(VUT, m.match),
+        m.inv_match === nothing ? nothing : convert(VUT, m.inv_match)
+    )
 end
 
 """
@@ -71,7 +76,7 @@ Matching{U}(v::V) where {U, V <: AbstractVector} = Matching{U, V}(v, nothing)
 Construct a matching from forward and inverse matchings.
 """
 function Matching{U}(v::V, iv::Union{V, Nothing}) where {U, V <: AbstractVector}
-    Matching{U, V}(v, iv)
+    return Matching{U, V}(v, iv)
 end
 
 """
@@ -81,7 +86,7 @@ Construct a matching from a vector, inferring the unassigned type. The inverse m
 is not stored.
 """
 function Matching(v::V) where {U, V <: AbstractVector{Union{U, Int}}}
-    Matching{@isdefined(U) ? U : Unassigned, V}(v, nothing)
+    return Matching{@isdefined(U) ? U : Unassigned, V}(v, nothing)
 end
 
 """
@@ -91,7 +96,7 @@ Construct an empty matching with `m` vertices, all unassigned. The inverse match
 stored.
 """
 function Matching(m::Int)
-    Matching{Unassigned}(Union{Int, Unassigned}[unassigned for _ in 1:m], nothing)
+    return Matching{Unassigned}(Union{Int, Unassigned}[unassigned for _ in 1:m], nothing)
 end
 
 """
@@ -100,15 +105,17 @@ end
 Construct an empty matching with `m` vertices and custom unassigned type `U`.
 """
 function Matching{U}(m::Int) where {U}
-    Matching{Union{Unassigned, U}}(Union{Int, Unassigned, U}[unassigned for _ in 1:m],
-        nothing)
+    return Matching{Union{Unassigned, U}}(
+        Union{Int, Unassigned, U}[unassigned for _ in 1:m],
+        nothing
+    )
 end
 
 Base.size(m::Matching) = Base.size(m.match)
 Base.getindex(m::Matching, i::Integer) = m.match[i]
 Base.iterate(m::Matching, state...) = iterate(m.match, state...)
 function Base.copy(m::Matching{U}) where {U}
-    Matching{U}(copy(m.match), m.inv_match === nothing ? nothing : copy(m.inv_match))
+    return Matching{U}(copy(m.match), m.inv_match === nothing ? nothing : copy(m.inv_match))
 end
 
 """
@@ -147,7 +154,7 @@ Append an element to the source vertices of the matching `m`, and match it to `v
 """
 function Base.push!(m::Matching, v)
     push!(m.match, v)
-    if v isa Integer && m.inv_match !== nothing
+    return if v isa Integer && m.inv_match !== nothing
         for vv in (length(m.inv_match) + 1):v
             push!(m.inv_match, unassigned)
         end
@@ -161,8 +168,10 @@ end
 Populate the inverse matching if it is not already computed. The optional parameter `N`
 specifies the size of the inverse matching vector.
 """
-function complete(m::Matching{U},
-        N = maximum((x for x in m.match if isa(x, Int)); init = 0)) where {U}
+function complete(
+        m::Matching{U},
+        N = maximum((x for x in m.match if isa(x, Int)); init = 0)
+    ) where {U}
     m.inv_match !== nothing && return m
     inv_match = Union{U, Int}[unassigned for _ in 1:N]
     for (i, eq) in enumerate(m.match)
@@ -178,7 +187,7 @@ end
 Throw an error if the matching does not have the inverse matching computed.
 """
 @noinline function require_complete(m::Matching)
-    m.inv_match === nothing &&
+    return m.inv_match === nothing &&
         throw(ArgumentError("Backwards matching not defined. `complete` the matching first."))
 end
 

--- a/src/maximal_matching.jl
+++ b/src/maximal_matching.jl
@@ -4,8 +4,10 @@
 Try to construct an augmenting path in matching and if such a path is found,
 update the matching accordingly.
 """
-function construct_augmenting_path!(matching::Matching, g::BipartiteGraph, vsrc, dstfilter,
-        dcolor = falses(ndsts(g)), scolor = nothing)
+function construct_augmenting_path!(
+        matching::Matching, g::BipartiteGraph, vsrc, dstfilter,
+        dcolor = falses(ndsts(g)), scolor = nothing
+    )
     scolor === nothing || (scolor[vsrc] = true)
 
     # if a `vdst` is unassigned and the edge `vsrc <=> vdst` exists
@@ -20,8 +22,10 @@ function construct_augmenting_path!(matching::Matching, g::BipartiteGraph, vsrc,
     for vdst in 𝑠neighbors(g, vsrc)
         (dstfilter(vdst) && !dcolor[vdst]) || continue
         dcolor[vdst] = true
-        if construct_augmenting_path!(matching, g, matching[vdst], dstfilter, dcolor,
-            scolor)
+        if construct_augmenting_path!(
+                matching, g, matching[vdst], dstfilter, dcolor,
+                scolor
+            )
             matching[vdst] = vsrc
             return true
         end
@@ -38,7 +42,8 @@ return `false` may not be matched.
 """
 function maximal_matching(
         g::BipartiteGraph, ::Type{U} = Unassigned; srcfilter = vsrc -> true,
-        dstfilter = vdst -> true) where {U}
+        dstfilter = vdst -> true
+    ) where {U}
     matching = Matching{U}(max(nsrcs(g), ndsts(g)))
     foreach(Iterators.filter(srcfilter, 𝑠vertices(g))) do vsrc
         construct_augmenting_path!(matching, g, vsrc, dstfilter)

--- a/src/pretty_printing.jl
+++ b/src/pretty_printing.jl
@@ -16,7 +16,7 @@ end
 Construct a [`BipartiteAdjacencyList`](@ref) without highlighting.
 """
 function BipartiteAdjacencyList(u::Union{Vector{Int}, Nothing})
-    BipartiteAdjacencyList(u, nothing, unassigned)
+    return BipartiteAdjacencyList(u, nothing, unassigned)
 end
 
 """
@@ -42,7 +42,7 @@ struct HighlightInt
 end
 Base.typeinfo_implicit(::Type{HighlightInt}) = true
 function Base.show(io::IO, hi::HighlightInt)
-    if hi.match
+    return if hi.match
         printstyled(io, "(", color = hi.highlight)
         printstyled(io, hi.i, color = hi.highlight)
         printstyled(io, ")", color = hi.highlight)
@@ -58,7 +58,7 @@ function Base.show(io::IO, l::BipartiteAdjacencyList)
     else
         printstyled(io, "  ")
     end
-    if l.u === nothing
+    return if l.u === nothing
         printstyled(io, '⋅', color = :light_black)
     elseif isempty(l.u)
         printstyled(io, '∅', color = :light_black)
@@ -70,7 +70,7 @@ function Base.show(io::IO, l::BipartiteAdjacencyList)
         function choose_color(i)
             solvable = i in l.highlight_u
             matched = i == match
-            if !matched && solvable
+            return if !matched && solvable
                 :default
             elseif !matched && !solvable
                 :light_black
@@ -82,15 +82,21 @@ function Base.show(io::IO, l::BipartiteAdjacencyList)
         end
         if !isempty(setdiff(l.highlight_u, l.u))
             # Only for debugging, shouldn't happen in practice
-            print(io,
+            print(
+                io,
                 map(union(l.u, l.highlight_u)) do i
-                    HighlightInt(i, !(i in l.u) ? :light_red : choose_color(i),
-                        i == match)
-                end)
+                    HighlightInt(
+                        i, !(i in l.u) ? :light_red : choose_color(i),
+                        i == match
+                    )
+                end
+            )
         else
-            print(io, map(l.u) do i
-                HighlightInt(i, choose_color(i), i == match)
-            end)
+            print(
+                io, map(l.u) do i
+                    HighlightInt(i, choose_color(i), i == match)
+                end
+            )
         end
     end
 end
@@ -123,7 +129,7 @@ A matrix view of a [`BipartiteGraph`](@ref) for pretty-printing. Provides a tabu
 representation with source and destination adjacency information.
 """
 struct BipartiteGraphPrintMatrix <:
-       AbstractMatrix{Union{Label, Int, BipartiteAdjacencyList}}
+    AbstractMatrix{Union{Label, Int, BipartiteAdjacencyList}}
     bpg::BipartiteGraph
 end
 Base.size(bgpm::BipartiteGraphPrintMatrix) = (max(nsrcs(bgpm.bpg), ndsts(bgpm.bpg)) + 1, 3)
@@ -134,20 +140,26 @@ function Base.getindex(bgpm::BipartiteGraphPrintMatrix, i::Integer, j::Integer)
     elseif j == 1
         return i - 1
     elseif j == 2
-        return BipartiteAdjacencyList(i - 1 <= nsrcs(bgpm.bpg) ?
-                                      𝑠neighbors(bgpm.bpg, i - 1) : nothing)
+        return BipartiteAdjacencyList(
+            i - 1 <= nsrcs(bgpm.bpg) ?
+                𝑠neighbors(bgpm.bpg, i - 1) : nothing
+        )
     elseif j == 3
-        return BipartiteAdjacencyList(i - 1 <= ndsts(bgpm.bpg) ?
-                                      𝑑neighbors(bgpm.bpg, i - 1) : nothing)
+        return BipartiteAdjacencyList(
+            i - 1 <= ndsts(bgpm.bpg) ?
+                𝑑neighbors(bgpm.bpg, i - 1) : nothing
+        )
     else
         @assert false
     end
 end
 
 function Base.show(io::IO, b::BipartiteGraph)
-    print(io, "BipartiteGraph with (", length(b.fadjlist), ", ",
-        isa(b.badjlist, Int) ? b.badjlist : length(b.badjlist), ") (𝑠,𝑑)-vertices\n")
-    Base.print_matrix(io, BipartiteGraphPrintMatrix(b))
+    print(
+        io, "BipartiteGraph with (", length(b.fadjlist), ", ",
+        isa(b.badjlist, Int) ? b.badjlist : length(b.badjlist), ") (𝑠,𝑑)-vertices\n"
+    )
+    return Base.print_matrix(io, BipartiteGraphPrintMatrix(b))
 end
 
 """
@@ -160,8 +172,10 @@ function print_hyperedge_hint(io::IO, ::Type{V}, graph::HyperGraph{V}, edge_i::I
 
 function Base.show(io::IO, graph::HyperGraph{V}) where {V}
     printstyled(io, get(io, :cgraph_name, "HyperGraph"); color = :blue, bold = true)
-    println(io, " with ", length(graph.labels),
-        " vertices and ", nsrcs(graph.graph), " hyperedges")
+    println(
+        io, " with ", length(graph.labels),
+        " vertices and ", nsrcs(graph.graph), " hyperedges"
+    )
     compact = get(io, :compact, false)
     for edge_i in 𝑠vertices(graph.graph)
         if compact && edge_i > 5
@@ -177,4 +191,5 @@ function Base.show(io::IO, graph::HyperGraph{V}) where {V}
         end
         println(io, graph.invmap[edge_idxs[end]], ">")
     end
+    return
 end

--- a/test/matching.jl
+++ b/test/matching.jl
@@ -32,7 +32,9 @@ end
     m[2] = 4
     m2 = convert(
         Matching{
-            Union{Unassigned, String}, Vector{Union{Unassigned, String, Int}}}, m)
+            Union{Unassigned, String}, Vector{Union{Unassigned, String, Int}},
+        }, m
+    )
     @test m2 isa Matching{Union{Unassigned, String}, Vector{Union{Unassigned, String, Int}}}
 end
 


### PR DESCRIPTION
## Summary
- Updated CI workflow to use `fredrikekre/runic-action@v1` instead of JuliaFormatter
- Removed `.JuliaFormatter.toml` configuration file
- Reformatted all source files with Runic.jl

## Changes
This PR migrates the code formatting from JuliaFormatter with SciMLStyle to Runic.jl. Runic.jl is an opinionated formatter (similar to Go's gofmt) that requires no configuration.

Key differences from JuliaFormatter:
- Explicit `return` statements are added where implicit
- Different indentation and alignment for continuation lines
- Consistent multiline formatting for function arguments

## Test plan
- [ ] CI format check passes with Runic.jl
- [ ] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)