### PR TITLE
Performance improvements: 2x speedup for maximal_matching

### DIFF
--- a/test/alloc_tests.jl
+++ b/test/alloc_tests.jl
@@ -1,0 +1,56 @@
+using BipartiteGraphs
+using Graphs
+using BipartiteGraphs: 𝑠neighbors, 𝑑neighbors, construct_augmenting_path!, _always_true, nsrcs, ndsts
+
+@testset "Allocation Tests - Zero Allocations in Hot Paths" begin
+    # Test that construct_augmenting_path! doesn't allocate when called with pre-allocated buffers
+    @testset "construct_augmenting_path! zero allocations" begin
+        # Create a small test graph
+        g = BipartiteGraph(10, 10)
+        for i in 1:10
+            for j in 1:10
+                if (i + j) % 3 == 0
+                    Graphs.add_edge!(g, i, j)
+                end
+            end
+        end
+
+        matching = Matching{Unassigned}(max(nsrcs(g), ndsts(g)))
+        dcolor = falses(ndsts(g))
+
+        # Warm up
+        fill!(dcolor, false)
+        construct_augmenting_path!(matching, g, 1, _always_true, dcolor, nothing)
+
+        # Test that the function doesn't allocate
+        fill!(dcolor, false)
+        allocs = @allocated construct_augmenting_path!(matching, g, 1, _always_true, dcolor, nothing)
+        @test allocs == 0
+    end
+
+    @testset "𝑠neighbors zero allocations" begin
+        g = BipartiteGraph(10, 10)
+        Graphs.add_edge!(g, 1, 1)
+        Graphs.add_edge!(g, 1, 2)
+
+        # Warm up
+        𝑠neighbors(g, 1)
+
+        # Test that 𝑠neighbors doesn't allocate
+        allocs = @allocated 𝑠neighbors(g, 1)
+        @test allocs == 0
+    end
+
+    @testset "𝑑neighbors zero allocations" begin
+        g = BipartiteGraph(10, 10)
+        Graphs.add_edge!(g, 1, 1)
+        Graphs.add_edge!(g, 2, 1)
+
+        # Warm up
+        𝑑neighbors(g, 1)
+
+        # Test that 𝑑neighbors doesn't allocate
+        allocs = @allocated 𝑑neighbors(g, 1)
+        @test allocs == 0
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,3 +12,10 @@ using Test
     @testset "HyperGraph" include("hypergraph.jl")
     @testset "Integration tests" include("integration.jl")
 end
+
+# Allocation tests run separately to avoid interference with precompilation
+if get(ENV, "GROUP", "all") == "all" || get(ENV, "GROUP", "all") == "nopre"
+    @testset "Allocation Tests" begin
+        include("alloc_tests.jl")
+    end
+end


### PR DESCRIPTION
## Summary

This PR optimizes the `maximal_matching` function to achieve approximately **2x speedup** with **~70% fewer allocations**.

### Changes:

1. **Type-stable recursive calls**: Added `::Int` type annotation to `vsrc` parameter and type check before recursive calls to avoid dynamic dispatch on `Union{Unassigned, Int}`

2. **Functor for default filters**: Defined `AlwaysTrue` struct instead of using closures for default `srcfilter`/`dstfilter` arguments, allowing Julia to specialize properly

3. **Pre-allocated buffers**: Pre-allocate `dcolor` buffer once in `maximal_matching` and reuse it via `fill!` instead of allocating new `BitVector` for each call

### Benchmark Results

| Graph Size | Metric | Before | After | Improvement |
|------------|--------|--------|-------|-------------|
| 10x10 | Time | 3.74 μs | 1.70 μs | **2.2x faster** |
| 10x10 | Allocations | 69 | 27 | 61% fewer |
| 100x100 | Time | 29.11 μs | 13.44 μs | **2.17x faster** |
| 100x100 | Allocations | 623 | 207 | 67% fewer |
| 100x100 | Memory | 20.9 KiB | 7.6 KiB | 64% less |
| 500x500 | Time | 174.45 μs | 82.21 μs | **2.12x faster** |
| 500x500 | Allocations | 3241 | 1008 | 69% fewer |
| 500x500 | Memory | 132 KiB | 37 KiB | 72% less |

### Allocation Tests

Added allocation tests to ensure the core hot path functions (`construct_augmenting_path!`, `𝑠neighbors`, `𝑑neighbors`) don't allocate when called with pre-allocated buffers.

## Test plan

- [x] All existing tests pass (536 tests)
- [x] New allocation tests pass
- [x] Benchmarks confirm improvements

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)