### PR TITLE
Disable downgrade tests and fix runic CI

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -14,6 +14,7 @@ on:
       - 'benchmark/**'
 jobs:
   test:
+    if: false  # Disabled: downgrade tests need review. See issue for details.
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -14,6 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1'
       - uses: fredrikekre/runic-action@v1
         with:
           version: '1'


### PR DESCRIPTION
## Summary

- Disables the downgrade CI tests by adding `if: false` to the job in `.github/workflows/Downgrade.yml`
- Adds Julia setup step to FormatCheck.yml for runic-action (required for runic to work)

## Motivation

The downgrade tests need another look to ensure they are testing the right things. This PR temporarily disables them.

The FormatCheck.yml fix adds the Julia setup step that runic-action requires.

## Related

See issue for tracking re-enablement of downgrade tests.

## Test plan

- [x] CI should skip the downgrade workflow
- [x] Other CI workflows should still run normally
- [x] Runic format check should now work with Julia available

🤖 Generated with [Claude Code](https://claude.com/claude-code)