### PR TITLE
Centralize CI on SciML reusable workflows (@v1)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,14 +5,10 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"
       - "/docs"
-      - "/test"
     schedule:
       interval: "daily"
     groups:

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -15,18 +15,8 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@latest
-        with:
-          version: 'lts'
-      - run: sudo apt-get update && sudo apt-get install -y xorg-dev mesa-utils xvfb libgl1 freeglut3-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxext-dev
-      - name: Install dependencies
-        run: DISPLAY=:0 xvfb-run -s '-screen 0 1024x768x24' julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
-      - name: Build and deploy
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key
-          JULIA_DEBUG: "Documenter"
-        run: DISPLAY=:0 xvfb-run -s '-screen 0 1024x768x24' julia --project=docs/ --code-coverage=user docs/make.jl
+    uses: "SciML/.github/.github/workflows/documentation.yml@v1"
+    with:
+      julia-version: "lts"
+      debug-documenter: true
+    secrets: "inherit"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -15,23 +15,14 @@ on:
 jobs:
   test:
     if: false  # Disabled: downgrade tests need review. See issue for details.
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        downgrade_mode: ['alldeps']
         julia-version: ['1.10']
         group: ['InterfaceI']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@1
-      - uses: julia-actions/julia-runtest@1
-        with:
-          ALLOW_RERESOLVE: false
-        env:
-          GROUP: ${{ matrix.group }}
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "${{ matrix.julia-version }}"
+      group: "${{ matrix.group }}"
+      skip: "Pkg,TOML"
+      allow-reresolve: false
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,5 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,5 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.0 
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -28,7 +28,7 @@ jobs:
           - "1"
           - "lts"
           - "pre"
-    uses: "SciML/.github/.github/workflows/tests.yml@master"
+    uses: "SciML/.github/.github/workflows/tests.yml@v1"
     with:
       julia-version: "${{ matrix.version }}"
       # Disable cache for self-hosted runners since they persist between runs

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,4 +1,5 @@
 [default.extend-words]
+CMO = "CMO"
 nin = "nin"
 nd = "nd"
 Strat = "Strat"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Converts all CI to the centralized SciML reusable workflows, pinned to `@v1` with `secrets: "inherit"` on every caller.

## Converted (inline -> central caller)
- **Documentation.yml**: inline build -> `documentation.yml@v1` (`julia-version: lts`, `debug-documenter: true`, coverage over `src,ext`). Dropped the `xorg/xvfb/OpenGL` apt setup — the docs build (Documenter + Graphs + SparseArrays only) has no graphical dependencies, so it is unnecessary boilerplate.
- **FormatCheck.yml**: inline `fredrikekre/runic-action` -> `runic.yml@v1`.
- **SpellCheck.yml**: inline `crate-ci/typos` -> `spellcheck.yml@v1`.
- **Downgrade.yml**: inline -> `downgrade.yml@v1`. Preserved `if: false` (still disabled), `julia-version: 1.10`, `group: InterfaceI`, `skip: Pkg,TOML`, `allow-reresolve: false`.
- **Tests.yml**: already a caller; bumped ref `@master` -> `@v1`. Matrix preserved exactly (`1`/`lts`/`pre`, `coverage: false`, self-hosted/cache vars).

## Added
- None — all five applicable checks (Tests, Documentation, Runic, SpellCheck, Downgrade) already existed.

## Cleanup
- **dependabot.yml**: removed the `crate-ci/typos` ignore; trimmed the `julia` block `/test` entry (no `test/Project.toml` exists); kept `github-actions` (weekly) and `julia` (daily, group all-julia-packages) blocks.
- No `CompatHelper.yml` present. `TagBot.yml` unchanged.

## Formatting / spelling
- **Runic**: ran `Runic.main(["--inplace","."])` (v1.7.0) — no changes; repo already ran Runic inline and is clean.
- **typos**: 0 prose fixes. The only findings were the domain term `CMO` (in `DiCMOBiGraph` / `CMONeighbors`), a false positive — added `CMO` to `.typos.toml` `extend-words` rather than editing identifiers. `typos .` now exits 0.

## Heads up
Check names change (jobs now run as reusable-workflow calls), so any branch-protection **required status checks** will need updating to the new names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)