### PR TITLE
Canonical CI cleanup: TagBot thin-caller + downgrade-caller cleanup

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -16,11 +16,10 @@ jobs:
   test:
     strategy:
       matrix:
-        julia-version: ['1.10']
+        julia-version: ['lts']
         group: ['InterfaceI']
     uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
     with:
       julia-version: "${{ matrix.julia-version }}"
       group: "${{ matrix.group }}"
-      skip: "Pkg,TOML"
     secrets: "inherit"

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,15 +1,9 @@
-name: TagBot
+name: "TagBot"
 on:
   issue_comment:
-    types:
-      - created
+    types: [created]
   workflow_dispatch:
 jobs:
-  TagBot:
-    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: JuliaRegistries/TagBot@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}
+  tagbot:
+    uses: "SciML/.github/.github/workflows/tagbot.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
## Canonical CI cleanup

- **TagBot**: replaced the inlined `JuliaRegistries/TagBot` workflow (permissions block + steps) with the canonical `SciML/.github` `tagbot.yml@v1` thin caller. This repo is a single package (no `lib/` subpackages), so the single-package caller form is used.
- **Downgrade caller**: removed the hand-listed stdlib `skip` input (`Pkg,TOML` — now auto-populated centrally) and changed the matrix downgrade Julia floor `1.10` to the `lts` alias.
- No monorepo subpackage matrix needed (no registered `lib/<Name>` subpackages).
- `.typos.toml` step skipped (already present at repo root).
- `[compat] julia` floors were not touched.

Ignore until reviewed by @ChrisRackauckas.