### PR TITLE
Canonicalize test units to @safetestset

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,13 +20,15 @@ DataStructures = "0.18, 0.19"
 DocStringExtensions = "0.8, 0.9"
 Graphs = "1.9"
 PrecompileTools = "1"
+SafeTestsets = "0.1, 1"
 SparseArrays = "1"
 Test = "1"
 julia = "1.10"
 
 [extras]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Pkg", "Test"]
+test = ["Pkg", "SafeTestsets", "Test"]

--- a/test/alloc_tests.jl
+++ b/test/alloc_tests.jl
@@ -1,5 +1,6 @@
 using BipartiteGraphs
 using Graphs
+using Test
 using BipartiteGraphs: 𝑠neighbors, 𝑑neighbors, construct_augmenting_path!, _always_true, nsrcs, ndsts
 
 @testset "Allocation Tests - Zero Allocations in Hot Paths" begin

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -3,6 +3,7 @@ Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 BipartiteGraphs = "caf10ac8-0290-4205-88aa-f15908547e8d"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
@@ -12,5 +13,6 @@ BipartiteGraphs = { path = "../.." }
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"
 Pkg = "1"
+SafeTestsets = "0.1, 1"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,9 +1,9 @@
-using BipartiteGraphs
-using Aqua
-using JET
-using Test
+using SafeTestsets
 
-@testset "Aqua" begin
+@safetestset "Aqua" begin
+    using BipartiteGraphs
+    using Aqua
+    using Test
     Aqua.test_all(BipartiteGraphs; unbound_args = false, deps_compat = false)
     # Aqua unbound type parameters: 1 found (Matching(v::V) where {U, V<:AbstractArray{Union{Int64, U}, 1}}
     # at src/matching.jl:88) — tracked in https://github.com/SciML/BipartiteGraphs.jl/issues/36
@@ -13,7 +13,10 @@ using Test
     @test_broken false
 end
 
-@testset "JET" begin
+@safetestset "JET" begin
+    using BipartiteGraphs
+    using JET
+    using Test
     # JET.report_package finds 10 possible errors stemming from the Union-typed `fadjlist`/`badjlist`
     # fields of BipartiteGraph/HyperGraph (no-matching-method on push!/+/searchsortedfirst/deleteat!/
     # Base.OneTo/empty! over Union{Int64, Vector{...}}) — tracked in

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Pkg
 using BipartiteGraphs
 using Graphs
 using Test
+using SafeTestsets
 
 const GROUP = get(ENV, "GROUP", "All")
 
@@ -11,18 +12,16 @@ if GROUP == "QA"
     include("qa/qa.jl")
 else
     @testset "BipartiteGraphs.jl" begin
-        @testset "Matching" include("matching.jl")
-        @testset "BipartiteGraph" include("bipartite_graph.jl")
-        @testset "`maximal_matching`" include("maximal_matching.jl")
-        @testset "DiCMOBiGraph" include("dicmobigraph.jl")
-        @testset "Condensation graphs" include("condensation_graphs.jl")
-        @testset "Pretty printing" include("pretty_printing.jl")
-        @testset "HyperGraph" include("hypergraph.jl")
-        @testset "Integration tests" include("integration.jl")
+        @safetestset "Matching" begin include("matching.jl") end
+        @safetestset "BipartiteGraph" begin include("bipartite_graph.jl") end
+        @safetestset "`maximal_matching`" begin include("maximal_matching.jl") end
+        @safetestset "DiCMOBiGraph" begin include("dicmobigraph.jl") end
+        @safetestset "Condensation graphs" begin include("condensation_graphs.jl") end
+        @safetestset "Pretty printing" begin include("pretty_printing.jl") end
+        @safetestset "HyperGraph" begin include("hypergraph.jl") end
+        @safetestset "Integration tests" begin include("integration.jl") end
     end
 
     # Allocation tests run separately to avoid interference with precompilation
-    @testset "Allocation Tests" begin
-        include("alloc_tests.jl")
-    end
+    @safetestset "Allocation Tests" begin include("alloc_tests.jl") end
 end


### PR DESCRIPTION
## Summary

Wraps each independent top-level test unit in `@safetestset` so each runs in its own fresh module, matching OrdinaryDiffEq's canonical test structure. This gives isolation between test units (no symbol/state leakage between files) and world-age safety.

This repo was classified as **plain-@testset**: `runtests.jl` invoked each unit as `@testset "X" include("x.jl")`, and the QA group's `qa.jl` had two plain `@testset` units.

## Changes

- **`test/runtests.jl`**: each `@testset "X" include("x.jl")` unit -> `@safetestset "X" begin include("x.jl") end` (Matching, BipartiteGraph, `maximal_matching`, DiCMOBiGraph, Condensation graphs, Pretty printing, HyperGraph, Integration tests), and the trailing Allocation Tests block likewise. The outer `@testset "BipartiteGraphs.jl"` grouping wrapper is kept (`@safetestset` nests fine inside `@testset`). Each included file already carries its own `using` lines and uses only Base/Test macros (`@test`, `@testset`, `@test_throws`, `@allocated`), so no world-age include-extraction trick was needed.
- **`test/alloc_tests.jl`**: add `using Test` for self-containment (it previously relied on `Test` leaking from `runtests.jl`).
- **`test/qa/qa.jl`**: the two plain `@testset` units (Aqua, JET) -> `@safetestset`, each with its own `using` block. `@test_broken` assertions preserved verbatim.
- **Deps**: add `SafeTestsets` to `test` deps — root `Project.toml` `[extras]`/`[targets].test`/`[compat]` (`SafeTestsets = "0.1, 1"`), and `test/qa/Project.toml` `[deps]`/`[compat]` since the QA group activates its own env. `using SafeTestsets` added to `runtests.jl` and `qa.jl`.

The GROUP-dispatch ladder, run path, and all assertions are unchanged — same tests run with the same assertions; units are only wrapped in `@safetestset` and made self-contained.

## Verification

Verified locally with `julia +1.11`:
- `GROUP=Core` passes: 536 tests in `BipartiteGraphs.jl` + 3 Allocation Tests, all green.
- `GROUP=QA` passes: Aqua (`@test_broken` x2) and JET (`@test_broken` x1) ran as `@safetestset`, broken markers as expected.

---
Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)