### PR TITLE
Fix Downgrade CI: drop stale InterfaceI test group

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -14,12 +14,8 @@ on:
       - 'benchmark/**'
 jobs:
   test:
-    strategy:
-      matrix:
-        julia-version: ['lts']
-        group: ['InterfaceI']
+    name: "Downgrade"
     uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
     with:
-      julia-version: "${{ matrix.julia-version }}"
-      group: "${{ matrix.group }}"
+      julia-version: "lts"
     secrets: "inherit"


### PR DESCRIPTION
## Problem

The `Downgrade` workflow on `master` is failing with:

```
ERROR: LoadError: ArgumentError: run_tests (folder mode): GROUP="InterfaceI" is not "All"/"Core"/"QA" and is not a group declared in test_groups.toml (declared: ["Core", "QA"]). Add it to test_groups.toml or fix the GROUP value.
```

`.github/workflows/Downgrade.yml` hardcoded `group: ['InterfaceI']` — a group name left over from before the SciMLTesting v1.2 folder-model migration. The current `test/test_groups.toml` only declares `Core` and `QA`, so `run_tests()` rejects `InterfaceI`.

## Fix

Drop the matrix and the `group` input so the centralized `downgrade.yml@v1` runs with `GROUP=""`, which folder mode resolves to `"All"` (i.e. `Core` + `QA`). This matches the convention used by other converted repos such as SciMLOperators.jl.

## Local verification (Julia 1.10.11 / lts)

- Reproduced the failure: `GROUP=InterfaceI julia +lts --project=. -e 'using Pkg; Pkg.test()'` errors exactly as CI does.
- Verified the fix: `GROUP="" julia +lts --project=. -e 'using Pkg; Pkg.test()'` runs the full suite green:

```
Core/alloc_tests.jl          3/3
Core/bipartite_graph.jl     90/90
Core/condensation_graphs.jl 13/13
Core/dicmobigraph.jl        18/18
Core/hypergraph.jl         341/341
Core/integration.jl         13/13
Core/matching.jl            40/40
Core/maximal_matching.jl    10/10
Core/pretty_printing.jl     11/11
     Testing BipartiteGraphs tests passed
```

Please ignore until reviewed by @ChrisRackauckas.
