### PR TITLE
Bump version to 0.1.9

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BipartiteGraphs"
 uuid = "caf10ac8-0290-4205-88aa-f15908547e8d"
 authors = ["Aayush Sabharwal <aayush.sabharwal@gmail.com>"]
-version = "0.1.8"
+version = "0.1.9"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"


### PR DESCRIPTION
Automated patch version bump (0.1.8 -> 0.1.9) to release unreleased commits on `master` via JuliaRegistrator.