### PR TITLE
Fix documentation concurrency ref check

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -11,7 +11,7 @@ concurrency:
   # Skip intermediate builds: always, but for the master branch.
   # Cancel intermediate builds: always, but for the master branch.
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.refs != 'refs/tags/*'}}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.ref_type != 'tag' }}
 
 jobs:
   build:


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- replace the undefined `github.refs` context with the supported `github.ref_type` context
- preserve the documentation workflow's concurrency policy: cancel superseded branch/PR runs, but not `master` or tag runs

## Root cause

The invalid expression was introduced in the repository's root commit (`cc1085fe3ee0d4c79925bd1d7635cc602b3d1d06`) and is still present on current `master`. `actionlint` reports `property "refs" is not defined`.

## Local verification

- `actionlint .github/workflows/Documentation.yml`
- `actionlint`
- `/home/crackauc/.juliaup/bin/julialauncher +1.12 --startup-file=no -m Runic --check .`
- `GROUP=All /home/crackauc/.juliaup/bin/julialauncher +1.12 --project=. -e 'using Pkg; Pkg.test()'` (539 assertions passed)