### PR TITLE
Enable BipartiteGraphs rendered docs QA

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -76,6 +76,7 @@ MatchedCondensationGraph
 ```@docs
 HyperGraph
 HyperEdge
+HyperGraphEdge
 Graphs.add_vertex!(::HyperGraph{V}, ::V) where {V}
 Graphs.add_edge!(::HyperGraph{V}, ::BipartiteGraphs.HyperGraphEdge{V}) where {V}
 Graphs.vertices(::HyperGraph)
@@ -87,4 +88,6 @@ Graphs.rem_edge!(::HyperGraph{V}, ::HyperEdge{V}) where {V}
 Graphs.edges(::HyperGraph{V}) where {V}
 Base.empty(::HyperGraph)
 Graphs.connected_components(::HyperGraph{V}) where {V}
+neighbors
+incident_edges
 ```

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -20,6 +20,7 @@ using Test
 #     element-type header when printing an array of `HighlightInt`.
 run_qa(
     BipartiteGraphs;
+    api_docs_kwargs = (; rendered = true),
     aqua_kwargs = (; unbound_args = false, deps_compat = false),
     explicit_imports = true,
     ei_kwargs = (;


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary
- Add missing rendered API entries for `HyperGraphEdge`, `neighbors`, and `incident_edges`.
- Enable SciMLTesting rendered public API docs QA with `api_docs_kwargs = (; rendered = true)`.

## Validation
- `git diff --check` passed.
- `run_qa(BipartiteGraphs; api_docs_kwargs = (; rendered = true), ...)` passed: Quality Assurance 13/13. Existing broken markers were unchanged: Aqua has 2 known broken checks, JET has 1 known broken check.
- `include("docs/make.jl")` completed locally under the repository's existing `warnonly` settings. Pre-existing warnings for `Graphs.rem_edge!(::HyperGraph{V}, ::HyperEdge{V})` and `Base.empty(::HyperGraph)` remain.
- `Pkg.test()` passed: 539 assertions across the package test files.
- Runic v1.7.0 passed over `src`, `test`, and `docs`.
