### PR TITLE
Use SciMLTesting default QA checks

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -20,9 +20,7 @@ using Test
 #     element-type header when printing an array of `HighlightInt`.
 run_qa(
     BipartiteGraphs;
-    api_docs_kwargs = (; rendered = true),
     aqua_kwargs = (; unbound_args = false, deps_compat = false),
-    explicit_imports = true,
     ei_kwargs = (;
         all_qualified_accesses_are_public = (;
             ignore = (:OneTo, :print_matrix, :typeinfo_implicit),


### PR DESCRIPTION
Removes redundant rendered-public-doc and explicit-import QA settings. SciMLTesting 2.3 enables both checks by default; the existing narrowly scoped Aqua and ExplicitImports configuration is unchanged.

Local verification: `Pkg.test()` passed (539 core assertions) with SciMLTesting 2.3.0; Runic check passed.

Ignore until reviewed by @ChrisRackauckas.