### PR TITLE
Bump BipartiteGraphs to v0.1.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BipartiteGraphs"
 uuid = "caf10ac8-0290-4205-88aa-f15908547e8d"
 authors = ["Aayush Sabharwal <aayush.sabharwal@gmail.com>"]
-version = "0.1.9"
+version = "0.1.10"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"


### PR DESCRIPTION
Bumps `BipartiteGraphs` **v0.1.9 → v0.1.10** (patch) so the accumulated unreleased `src/` changes on `master` can be registered.

**Rationale:** Merge pull request #45 from ChrisRackauckas-Claude/agent/fix-documentation-ref-context (docs/QA/compat/internal; no public API or behavior break)

Part of a sweep of SciML packages whose source changed since their last registered version without a version bump.

> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)