### PR TITLE
Migrate QA to SciMLTesting 2.4

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,6 +3,9 @@ import Graphs
 import SparseArrays
 
 const ExtMod = Base.get_extension(BipartiteGraphs, :BipartiteGraphsSparseArraysExt)
+const REPO_ROOT = abspath(joinpath(@__DIR__, ".."))
+const REPO_REMOTE = Documenter.Remotes.GitHub("SciML", "BipartiteGraphs.jl")
+const REPO_COMMIT = readchomp(`git -C $REPO_ROOT rev-parse HEAD`)
 
 cp("./docs/Manifest.toml", "./docs/src/assets/Manifest.toml", force = true)
 cp("./docs/Project.toml", "./docs/src/assets/Project.toml", force = true)
@@ -11,8 +14,11 @@ makedocs(
     sitename = "BipartiteGraphs.jl",
     authors = "Chris Rackauckas",
     modules = [BipartiteGraphs, ExtMod],
-    clean = true, doctest = false, linkcheck = true,
-    warnonly = [:docs_block, :missing_docs, :cross_references],
+    checkdocs = :exports,
+    remotes = Dict(
+        REPO_ROOT => (REPO_REMOTE, REPO_COMMIT),
+    ),
+    clean = true, doctest = true, linkcheck = true,
     format = Documenter.HTML(;
         assets = ["assets/favicon.ico"],
         canonical = "https://docs.sciml.ai/BipartiteGraphs/stable/",

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -84,9 +84,9 @@ Graphs.nv(::HyperGraph)
 Graphs.has_vertex(::HyperGraph{V}, ::V) where {V}
 Graphs.ne(::HyperGraph)
 Graphs.has_edge(::HyperGraph{V}, ::HyperEdge{V}) where {V}
-Graphs.rem_edge!(::HyperGraph{V}, ::HyperEdge{V}) where {V}
+Graphs.rem_edge!(::HyperGraph, ::HyperEdge)
 Graphs.edges(::HyperGraph{V}) where {V}
-Base.empty(::HyperGraph)
+Base.empty!(::HyperGraph)
 Graphs.connected_components(::HyperGraph{V}) where {V}
 neighbors
 incident_edges

--- a/src/BipartiteGraphs.jl
+++ b/src/BipartiteGraphs.jl
@@ -1,6 +1,6 @@
 module BipartiteGraphs
 
-using DocStringExtensions: DocStringExtensions, FIELDS, METHODLIST, TYPEDEF,
+using DocStringExtensions: DocStringExtensions, FIELDS, TYPEDEF,
     TYPEDFIELDS, TYPEDSIGNATURES
 using Graphs: Graphs, AbstractGraph, connected_components, dst, edges, edgetype,
     has_edge, has_vertex, inneighbors, ne, nv, outneighbors, src, vertices

--- a/src/bipartite_graph.jl
+++ b/src/bipartite_graph.jl
@@ -96,7 +96,7 @@ mutable struct BipartiteGraph{I <: Integer, M} <: Graphs.AbstractGraph{I}
 end
 
 """
-    $METHODLIST
+    $TYPEDSIGNATURES
 
 Construct a bipartite graph with `ne` edges, given the forward and backward
 adjacency lists. Instead of the backward adjacency list, an integer may be given

--- a/src/hypergraph.jl
+++ b/src/hypergraph.jl
@@ -140,7 +140,7 @@ end
 Graphs.edgetype(::HyperGraph{V}) where {V} = HyperEdge{V}
 
 """
-    $METHODLIST
+    $TYPEDSIGNATURES
 
 Check if a hyperedge exists in the hypergraph. The edge can be specified as a `HyperEdge`
 or as a collection of vertices.
@@ -171,7 +171,7 @@ function _edge_idx(g::HyperGraph{V}, vertices::HyperGraphEdge{V}) where {V}
 end
 
 """
-    $METHODLIST
+    $TYPEDSIGNATURES
 
 Remove a hyperedge from the hypergraph. The edge can be specified as a `HyperEdge` or as a
 collection of vertices. Returns `true` if the edge was removed, `false` if it did not exist.

--- a/src/matching.jl
+++ b/src/matching.jl
@@ -85,8 +85,10 @@ end
 Construct a matching from a vector, inferring the unassigned type. The inverse matching
 is not stored.
 """
-function Matching(v::V) where {U, V <: AbstractVector{Union{U, Int}}}
-    return Matching{@isdefined(U) ? U : Unassigned, V}(v, nothing)
+function Matching(v::AbstractVector{T}) where {T}
+    T <: Integer && return Matching{Unassigned}(v)
+    Int <: T || throw(MethodError(Matching, (v,)))
+    return Matching{T}(v)
 end
 
 """

--- a/src/pretty_printing.jl
+++ b/src/pretty_printing.jl
@@ -40,7 +40,6 @@ struct HighlightInt
     highlight::Symbol
     match::Bool
 end
-Base.typeinfo_implicit(::Type{HighlightInt}) = true
 function Base.show(io::IO, hi::HighlightInt)
     return if hi.match
         printstyled(io, "(", color = hi.highlight)
@@ -159,7 +158,7 @@ function Base.show(io::IO, b::BipartiteGraph)
         io, "BipartiteGraph with (", length(b.fadjlist), ", ",
         isa(b.badjlist, Int) ? b.badjlist : length(b.badjlist), ") (𝑠,𝑑)-vertices\n"
     )
-    return Base.print_matrix(io, BipartiteGraphPrintMatrix(b))
+    return Base.show(io, MIME"text/plain"(), BipartiteGraphPrintMatrix(b))
 end
 
 """

--- a/test/matching.jl
+++ b/test/matching.jl
@@ -21,6 +21,9 @@ end
     @test m[2] === unassigned
     @test m[3] == 3
 
+    integer_matching = Matching([1, 2, 3])
+    @test integer_matching isa Matching{Unassigned, Vector{Int}}
+
     # Test type conversion
     m2 = Matching{Unassigned}(m)
     @test eltype(m2) == Union{Unassigned, Int}

--- a/test/pretty_printing.jl
+++ b/test/pretty_printing.jl
@@ -12,6 +12,8 @@ using Test
     str = String(take!(io))
     @test contains(str, "BipartiteGraph")
     @test contains(str, "2")  # number of src or dst vertices
+    @test contains(str, "src")
+    @test contains(str, "dst")
 end
 
 @testset "BipartiteEdge printing" begin

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,18 +1,9 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 BipartiteGraphs = "caf10ac8-0290-4205-88aa-f15908547e8d"
-JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
-SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[sources]
-BipartiteGraphs = { path = "../.." }
 
 [compat]
 Aqua = "0.8"
-JET = "0.9,0.10,0.11"
-SafeTestsets = "0.1, 1"
 SciMLTesting = "2.4"
-Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,47 +1,4 @@
 using BipartiteGraphs
-using JET
 using SciMLTesting
-using Test
 
-# Aqua + ExplicitImports via the shared SciMLTesting harness.
-#
-# Aqua: `unbound_args`/`deps_compat` are disabled because of two pre-existing nits
-# tracked in https://github.com/SciML/BipartiteGraphs.jl/issues/36 (a genuinely
-# unbound type parameter in `Matching` and a `[compat]`-less `[extras]` entry).
-#
-# ExplicitImports: all four standard checks and both public-API checks run. Three
-# qualified accesses are unavoidable and so are ignored (per-check, minimal):
-#   * `OneTo` — `Base.OneTo` is the vertex-range type returned by `𝑑vertices`/
-#     condensation-graph `vertices`; it is public Base API as of Julia 1.11 but only
-#     retroactively marked, so the check flags it on the 1.10 LTS. Rewriting it to a
-#     `UnitRange` would change the return type, so the canonical name is kept.
-#   * `print_matrix` — the only routine for tabular `Base.show` of a matrix view.
-#   * `typeinfo_implicit` — the documented (internal) hook for suppressing the
-#     element-type header when printing an array of `HighlightInt`.
-run_qa(
-    BipartiteGraphs;
-    aqua_kwargs = (; unbound_args = false, deps_compat = false),
-    ei_kwargs = (;
-        all_qualified_accesses_are_public = (;
-            ignore = (:OneTo, :print_matrix, :typeinfo_implicit),
-        ),
-    ),
-)
-
-@testset "Aqua (known-broken nits, issue #36)" begin
-    # Aqua unbound type parameters: 1 found (Matching(v::V) where {U, V<:AbstractArray{Union{Int64, U}, 1}}
-    # at src/matching.jl:88) — tracked in https://github.com/SciML/BipartiteGraphs.jl/issues/36
-    @test_broken false
-    # Aqua deps_compat: `Pkg` in [extras] has no [compat] entry — tracked in
-    # https://github.com/SciML/BipartiteGraphs.jl/issues/36
-    @test_broken false
-end
-
-@testset "JET" begin
-    # JET.report_package finds 10 possible errors stemming from the Union-typed `fadjlist`/`badjlist`
-    # fields of BipartiteGraph/HyperGraph (no-matching-method on push!/+/searchsortedfirst/deleteat!/
-    # Base.OneTo/empty! over Union{Int64, Vector{...}}) — tracked in
-    # https://github.com/SciML/BipartiteGraphs.jl/issues/36
-    rep = JET.report_package(BipartiteGraphs; target_defined_modules = true)
-    @test_broken isempty(JET.get_reports(rep))
-end
+run_qa(BipartiteGraphs)


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary
- run the exact strict SciMLTesting 2.4 QA harness without local source overrides or exceptions
- repair the Matching constructor, public Base API usage, and definition-site documentation needed by strict checks
- enable strict rendered API docs and doctests

## Validation
- Pkg.test() on Julia 1.10 and 1.12
- strict run_qa(BipartiteGraphs) on Julia 1.10 and 1.12
- strict docs, doctests, and link checking
- Runic --check --diff and git diff --check