### PR TITLE
QA: load weakdeps so package extensions are actually scanned

### DIFF
--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -2,8 +2,10 @@
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 BipartiteGraphs = "caf10ac8-0290-4205-88aa-f15908547e8d"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 Aqua = "0.8"
 SciMLTesting = "2.4"
+SparseArrays = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,4 +1,9 @@
 using BipartiteGraphs
 using SciMLTesting
 
+# ExplicitImports only inspects an extension module once it exists, which requires the
+# extension's trigger package to be loaded. Without loading the weakdeps here,
+# BipartiteGraphsSparseArraysExt is silently skipped by the QA checks.
+using SparseArrays
+
 run_qa(BipartiteGraphs)


### PR DESCRIPTION
**Please ignore this PR until reviewed by @ChrisRackauckas.**

## Problem

`SciMLTesting.run_qa` runs ExplicitImports' checks. ExplicitImports *does* know about extensions — it reads the `[extensions]` table out of `Project.toml` — but it skips any extension whose module does not yet exist:

```julia
ext_mod = Base.get_extension(mod, Symbol(ext))
ext_mod === nothing && continue
```

An extension module only exists once its trigger (weakdep) package is loaded. The QA environment did not declare or load any weakdeps, so extension coverage was incidental rather than guaranteed.

## Change

* `test/qa/Project.toml`: add `SparseArrays` under `[deps]` (UUID matching the root `[weakdeps]` entry) with a `[compat]` entry mirroring the root bound (`"1"`).
* `test/qa/qa.jl`: `using SparseArrays` before `run_qa`, with a comment explaining why.

## Coverage

| Extension | Status |
|---|---|
| `BipartiteGraphsSparseArraysExt` | now scanned (explicitly) |

No extension is left unscanned — `SparseArrays` is the only weakdep, it is a stdlib, and it needs no special hardware or system libraries.

## Note on the pre-existing state

Worth being precise: this repo was not actually at zero coverage before. `Graphs.jl` has `SparseArrays` as a direct dependency, so `using BipartiteGraphs` already loaded `SparseArrays` transitively and the extension was already being scanned by accident. This PR makes that guaranteed instead of incidental — if `Graphs.jl` ever drops its `SparseArrays` dependency, the extension would silently fall out of QA coverage with no test failure to signal it.

## Findings / ignore entries

None. `BipartiteGraphsSparseArraysExt` is already clean under all ExplicitImports checks — no `ei_kwargs` ignore entries were added, and no extension source changes were needed.

## Verification

Proof that the extension module is genuinely in the scanned set (not just "QA still passes", which proves nothing since `run_qa` emits a fixed number of `@test`s regardless):

```
$ julia --project=test/qa -e '
    using BipartiteGraphs, SparseArrays, ExplicitImports
    println(:BipartiteGraphsSparseArraysExt, " => ",
            Base.get_extension(BipartiteGraphs, :BipartiteGraphsSparseArraysExt))
    for (k, v) in explicit_imports(BipartiteGraphs, pathof(BipartiteGraphs))
        println("MODULE SCANNED: ", k)
    end'

BipartiteGraphsSparseArraysExt => BipartiteGraphsSparseArraysExt
MODULE SCANNED: BipartiteGraphs
MODULE SCANNED: BipartiteGraphsSparseArraysExt
```

(`ExplicitImports` was added to `test/qa` temporarily for that probe only; it is not part of this diff.)

Individual checks against the extension:

```
--- check_no_implicit_imports ---              ok
--- check_all_qualified_accesses_via_owners --- ok
```

Local QA group run on this branch:

```
$ GROUP=QA julia --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA/qa.jl      |   20     20  1m19.3s
     Testing BipartiteGraphs tests passed
```

`test/qa/Manifest.toml` is a local build artifact and is not committed (covered by `.gitignore`).

---

**Follow-up:** the load-guard `@testset` that asserts the extension module actually exists (ExplicitImports silently skips an extension that fails to load) is *not* in this PR — it landed after this one merged. It is tracked separately.
