### PR TITLE
QA: assert extension modules actually load

### DIFF
--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -3,9 +3,11 @@ Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 BipartiteGraphs = "caf10ac8-0290-4205-88aa-f15908547e8d"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Aqua = "0.8"
 SciMLTesting = "2.4"
 SparseArrays = "1"
+Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,9 +1,16 @@
 using BipartiteGraphs
 using SciMLTesting
+using Test
 
 # ExplicitImports only inspects an extension module once it exists, which requires the
 # extension's trigger package to be loaded. Without loading the weakdeps here,
 # BipartiteGraphsSparseArraysExt is silently skipped by the QA checks.
 using SparseArrays
+
+# ExplicitImports silently skips an extension that fails to load, so assert the
+# extension modules actually exist rather than trusting a green run_qa.
+@testset "Extensions loaded" begin
+    @test Base.get_extension(BipartiteGraphs, :BipartiteGraphsSparseArraysExt) !== nothing
+end
 
 run_qa(BipartiteGraphs)


### PR DESCRIPTION
**Please ignore this PR until reviewed by @ChrisRackauckas.**

Follow-up to #51, which merged before this could be added to it.

## Problem: a skipped extension is indistinguishable from a clean one

ExplicitImports skips any extension whose module does not exist, without complaint:

```julia
ext_mod = Base.get_extension(mod, Symbol(ext))
ext_mod === nothing && continue
```

That `continue` is the whole problem. No warning, no failing test — the extension simply stops being checked and QA stays green. Because `run_qa` emits a fixed number of `@test`s (each ExplicitImports check folds all submodules into one assertion), a silently-skipped extension produces a summary *identical* to a fully-scanned clean one. Nothing in the output distinguishes the two.

There are two independent routes to that outcome:

1. **The trigger package is not loaded.** An extension module only exists once its weakdep is loaded. #51 addressed this by adding `SparseArrays` to `test/qa` and `using` it.
2. **The extension fails to load.** Even with the trigger present, a broken extension yields `nothing` from `get_extension` and is skipped — still reported clean. Nothing covers this today.

Route 1 is also worth belt-and-braces here: `Graphs.jl` has `SparseArrays` as a direct dependency, so `SparseArrays` arrives transitively regardless of the explicit `using`. That means #51's `using SparseArrays` is currently load-bearing only in principle — if it were ever removed, or if `Graphs.jl` dropped the dependency, coverage would vanish with no signal.

## Change

Assert the thing rather than inferring it from a green run:

```julia
@testset "Extensions loaded" begin
    @test Base.get_extension(BipartiteGraphs, :BipartiteGraphsSparseArraysExt) !== nothing
end
```

`Test` is added to `test/qa` deps/compat for `@testset` (`SciMLTesting` does not re-export it).

This converts "coverage happens to work" into "coverage is asserted" — both routes above now surface as a test failure.

## Verification

**The guard is a real assertion, not a tautology.** Negative control against a nonexistent extension name:

```
== real ext ==            (passes)
== negative control: nonexistent ext should FAIL ==
Test Failed at none:7
  Expression: Base.get_extension(BipartiteGraphs, :BipartiteGraphsNoSuchExt) !== nothing
   Evaluated: nothing !== nothing
```

**Local QA group run on this branch:**

```
$ GROUP=QA julia --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA/qa.jl      |   21     21  1m21.2s
     Testing BipartiteGraphs tests passed
```

21 tests, up from 20 on master — the one added test is the load guard, which confirms it actually executes rather than being silently skipped itself.

No `ei_kwargs` ignore entries were added and no extension source was changed; `BipartiteGraphsSparseArraysExt` is clean under all ExplicitImports checks.
