### PR TITLE
Drop [compat] majors whose successor is 2+ years old

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ BipartiteGraphsSparseArraysExt = "SparseArrays"
 
 [compat]
 DataStructures = "0.18, 0.19"
-DocStringExtensions = "0.8, 0.9"
+DocStringExtensions = "0.9"
 Graphs = "1.9"
 PrecompileTools = "1.1"
 SafeTestsets = "0.1, 1"


### PR DESCRIPTION
**Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

## What changed

Pure `[compat]` edits that **drop majors whose successor has been out for at least 2 years** (cutoff 2024-08-14). No code, tests, or package version were changed.

- `Project.toml` [deps] `DocStringExtensions`: `0.8, 0.9` → `0.9` (drop 0.8; DocStringExtensions 0.9.x first released 2022-05-26)

## Why

Once a newer major has been in the General registry for two years, the previous major is untested and unused. Declaring it only keeps a dead window in the resolver / downgrade graph. Remaining majors and their existing lower bounds are unchanged.

## Verification

Dates come from GitHub tags (and General registrator PRs where a tag was later rewritten). Not verified here: the full test suite, QA, or a live `julia-downgrade-compat` run.
